### PR TITLE
Mark pgserver as a typed package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgserver" # Required
-version = "0.0.4"  # Required
+version = "0.0.5"  # Required
 description = "Self-contained postgres server for your python applications" # Required
 readme = "README.md" # Optional
 requires-python = ">=3.8"

--- a/src/pgserver/__init__.py
+++ b/src/pgserver/__init__.py
@@ -1,2 +1,3 @@
 from ._commands import *
 from ._utils import *
+from ._utils import PostgresServer


### PR DESCRIPTION
Add `py.typed` to mark `pgserver` as a typed package.

Also adds `PostgresServer` as an explicit import (mypy didn't approve of the `import *`).