### PR TITLE
Set utf8 as default encoding for new databases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgserver" # Required
-version = "0.0.7"  # Required
+version = "0.0.9"  # Required
 description = "Self-contained postgres server for your python applications" # Required
 readme = "README.md" # Optional
 requires-python = ">=3.9"

--- a/src/pgserver/postgres_server.py
+++ b/src/pgserver/postgres_server.py
@@ -96,7 +96,7 @@ class PostgresServer:
                         pwd.getpwnam(self.system_user).pw_gid)
 
         if not (self.pgdata / 'PG_VERSION').exists():
-            initdb(['--auth=trust',  '--auth-local=trust',  '-U', self.postgres_user], pgdata=self.pgdata,
+            initdb(['--auth=trust', '--auth-local=trust', '--encoding=utf8', '-U', self.postgres_user], pgdata=self.pgdata,
                     user=self.system_user)
 
     def ensure_postgres_running(self) -> None:


### PR DESCRIPTION
This is necessary to prevent Windows systems from defaulting to Windows-specific character encodings. (It should be a no-op on Mac/Linux, which default to utf8 anyway.)